### PR TITLE
Refactor register_artwork

### DIFF
--- a/src/ff_interface.mligo
+++ b/src/ff_interface.mligo
@@ -1,15 +1,24 @@
+(**
+Feral File exhibition artwork structure
+*)
 type artwork =
-[@layout:comb]
 {
+  title : string;
   artist_name : string;
   fingerprint : string;
-  title : string;
-  token_start_id : nat;
   max_edition: nat;
+  token_start_id : nat;
 }
 
+(**
+Feral File exhibition artworks storage
+*)
 type artwork_storage = (bytes, artwork) map
 
+(**
+A map between bytes and nat. This is to help
+generating token start id with nat type.
+*)
 type bytes_nat_convert_map = (bytes, nat) map
 
 type ff_token_metadata =

--- a/testnet-test/register_artwork.ts
+++ b/testnet-test/register_artwork.ts
@@ -26,7 +26,6 @@ const mint = async function () {
       edition_size: 10,
       fingerprint: "IamFingerprint",
       title: "test",
-      token_start_id: 0,
       max_edition: 10
     }]).send();
     await op.confirmation()


### PR DESCRIPTION
In this PR, we do some refactoring for register_artwork.

- Made param be the first variable of the entry-point function
- Remove `token_start_id` from the function input
- Separate records for `artwork` and `artwork_parameter`
- use better naming for variables