### PR TITLE
Update Makefile and README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 .PHONY: api
 
-default: clean compile compile-storage
+default: clean compile-consts compile compile-storage
 
 ARCH=$(shell /usr/bin/uname -m)
 PWD=$(shell pwd)
+
+
+ifeq (${ARCH}, arm64)
 LIGO=docker run --rm -v ${PWD}:${PWD} -w ${PWD} ligolang/ligo:0.43.0
+else
+LIGO=ligo
+endif
 
 clean:
 	rm -rf ./compilation
@@ -20,25 +26,25 @@ compile:
 compile-storage:
 	${LIGO} compile storage src/ff_fa2_asset.mligo 'default_storage' -o compilation/storage.tz --file-constants src/global_constants/bytes_to_nat_array.json
 
-deploy:
-	./tools/with_venv.sh python ./tools/originate.py
-
 tc-init:
 	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client --endpoint $(shell jq -r .shell .env.json) config update
-	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client import secret key default unencrypted:$(shell jq -r .key .env.json) --force
+	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client import secret key ff-deployer unencrypted:$(shell jq -r .key .env.json) --force
+
+deploy: tc-deploy
 
 tc-dry-deploy: compile compile-storage
-	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client originate contract FFExhibition transferring 0 from default \
+	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client originate contract FFExhibition transferring 0 from ff-deployer \
 	running ./compilation/contract.tz -D --verbose-signing --burn-cap 15 --init '$(shell cat ./compilation/storage.tz)'
 
 tc-deploy: compile compile-storage
-	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client originate contract FFExhibition transferring 0 from default \
+	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client originate contract FFExhibition transferring 0 from ff-deployer \
 	running ./compilation/contract.tz --burn-cap 15 --init '$(shell cat ./compilation/storage.tz)'
 	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client forget all contracts --force
 
-# This command failed if it has already registered
+# NOTE: This command can only run one time for each network
+# since each global constant can only register once in a specific network
 tc-deploy-consts: compile-consts
-	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client register global constant '$(shell jq -r .text_code src/global_constants/bytes_to_nat.json)' from default --burn-cap 2
+	TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=yes tezos-client register global constant '$(shell jq -r .text_code src/global_constants/bytes_to_nat.json)' from ff-deployer --burn-cap 2
 
 test-register-artwork:
 	TEZOS_RPC_URL=$(shell jq -r .shell .env.json) \
@@ -74,20 +80,11 @@ test-remove-trustee:
 
 test-contract: test-register-artwork test-mint-editions test-authorized-transfer test-add-trustee test-remove-trustee
 
-env:
+git-init:
 	git submodule init
 	git submodule update
-	virtualenv .venv
-ifeq (${ARCH}, arm64)
-	CFLAGS="-I/opt/homebrew/Cellar/gmp/6.2.1_1/include/ -L/opt/homebrew/Cellar/gmp/6.2.1_1/lib/" \
-	LIB_DIR="/opt/homebrew/Cellar/libsecp256k1/0.1/lib" \
-	INCLUDE_DIR="/opt/homebrew/Cellar/libsecp256k1/0.1/include" \
-	./tools/with_venv.sh pip install --no-cache-dir pytezos
-else
-	CFLAGS="-I/usr/local/Cellar/gmp/6.2.1_1/include/ -L/usr/local/Cellar/gmp/6.2.1_1/lib/" \
-	LIB_DIR="/usr/local/Cellar/libsecp256k1/0.1/lib" \
-	INCLUDE_DIR="/usr/local/Cellar/libsecp256k1/0.1/include" \
-	./tools/with_venv.sh pip install --no-cache-dir pytezos
-endif
+
+env: git-init tc-init
+
 test:
 	${LIGO} run dry-run --entry-point main src/ff_fa2_asset.mligo 'Transfer ([])' 'default_storage'

--- a/README.md
+++ b/README.md
@@ -2,62 +2,40 @@
 
 ## Pre-requisite
 
-- ligo
-- python3
-- virtualenv
-- pytezos
+- [ligo](https://ligolang.org/docs/intro/installation/)
+- [tezos-client](https://wiki.tezos.com/build/clients/installation-and-setup)
+- docker (for mac user)
 
-## Setup Environments
+### ligo on Mac
 
-To set up the local environment, using the following command:
+Since there is no native build of ligo on mac, we leverage docker image to run ligo. You can test the ligo environment by:
 
+```sh
+alias ligo="docker run --rm -v "$PWD":"$PWD" -w "$PWD" ligolang/ligo:0.43.0"
+ligo version -version
 ```
+
+## Setup Environment
+
+To set up the local environment, we first copy `env.json.sample` to `.env.json` and set up the variables properly.
+After that, run the following command:
+
+```sh
 make env
 ```
 
-For some tools that requires further dependencies, we list them below.
-
-### Ligo
-
-We use ligo docker image as the ligo CLI.
-
-```
-$ alias ligo="docker run --rm -v "$PWD":"$PWD" -w "$PWD" ligolang/ligo:0.40.0"
-```
-
-And test the ligo tool,
-
-```
-$ ligo version -version
-```
-
-### Pytezos
-
-For different OS, there are some different requirements.
-
-#### Mac
-
-In mac, you need to install the following dependencies to ensure pytezos can well setup.
-
-```
-$ brew tap cuber/homebrew-libsecp256k1
-$ brew install libsodium libsecp256k1 gmp pkg-config
-```
-
-### Compile
+## Compile
 
 Use `make` to compile the contract code
 
-### Deploy
-
-Copy `env.json.sample` to `.env.jsom` and set up the variables properly.
+## Deploy
 
 Run
 
-```
+```sh
 make deploy
 ```
 
-### Test
+## Test
 
 Work in progress


### PR DESCRIPTION
In this PR, it re-organize Makefile and README.md

- change the default account for tezos-client to `ff-deployer`
- include `make tc-init` into `make env`
- remove un-used pytezos dependency