### PR TITLE
Add contract address as the parameter of `auth_transfer` signing

### DIFF
--- a/src/ff_custom_token.mligo
+++ b/src/ff_custom_token.mligo
@@ -53,10 +53,11 @@ let _authorized_transfer (transfers, ledger : authorized_transfer list * ledger)
           | Some o ->
             if o <> tx.from_
               then (failwith fa2_insufficient_balance : ledger)
-            else 
+            else
+              let contract_address = Bytes.pack Tezos.self_address in
               let p_bytes_to_ = Bytes.pack dst.to_ in
               let p_bytes_token_id = Bytes.pack dst.token_id in
-              let bytes_msg = Bytes.concat sig_prefix (Bytes.concat p_bytes_expiry (Bytes.concat p_bytes_to_ p_bytes_token_id)) in
+              let bytes_msg = Bytes.concat sig_prefix (Bytes.concat p_bytes_expiry (Bytes.concat contract_address (Bytes.concat p_bytes_to_ p_bytes_token_id))) in
               let bytes_sign_msg = Bytes.pack bytes_msg in
               let _ = fail_if_invalid_signature(tx.pk, dst.sig, bytes_sign_msg) in
               Big_map.update dst.token_id (Some dst.to_) ll

--- a/testnet-test/authorized_transfer.ts
+++ b/testnet-test/authorized_transfer.ts
@@ -51,10 +51,11 @@ const auth_transfer = async function () {
         const pk = await noXTZSigner.publicKey()
 
         let packedTimestamp = packData({ int: expiry }, { prim: 'timestamp' });
+        let contractAddress = packData({ string: <string>process.env.CONTRACT_ADDRESS }, { prim: 'address' });
         let packedTo = packData({ string: adminAddr }, { prim: 'address' });
         let packedTokenID = packData({ int: tokenID }, { prim: 'int' });
 
-        let bytesData = Buffer.from(packedTimestamp.concat(packedTo).concat(packedTokenID))
+        let bytesData = Buffer.from(packedTimestamp.concat(contractAddress).concat(packedTo).concat(packedTokenID))
 
         let prefix = Buffer.from("54657a6f73205369676e6564204d6573736167653a", "hex")
 


### PR DESCRIPTION
In order to prevent replay attacks from different blockchains, we add the contract address into the auth_transfer's request signature.