### PR TITLE
Reject execute entrypoints with extra XTZ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,12 @@ test-remove-trustee:
 	CONTRACT_ADDRESS=$(shell jq -r .contract .env.json) \
 	npm run test-remove-trustee
 
+test-action-with-xtz:
+	TEZOS_RPC_URL=$(shell jq -r .shell .env.json) \
+	DEPLOYER_PRIVATE_KEY=$(shell jq -r .key .env.json) \
+	CONTRACT_ADDRESS=$(shell jq -r .contract .env.json) \
+	npm run test-action-with-xtz
+
 test-contract: test-register-artwork test-mint-editions test-update-edition-metadata test-authorized-transfer test-burn-editions test-add-trustee test-remove-trustee
 
 git-init:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test-authorized-transfer": "ts-node testnet-test/authorized_transfer.ts",
     "test-add-trustee": "ts-node testnet-test/add_trustee.ts",
     "test-remove-trustee": "ts-node testnet-test/remove_trustee.ts",
+    "test-action-with-xtz": "ts-node testnet-test/action_with_xtz.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/src/ff_fa2_asset.mligo
+++ b/src/ff_fa2_asset.mligo
@@ -50,8 +50,17 @@ let fail_if_token_not_burnable (burnable : bool) : unit =
     then failwith ff_token_not_burnable
   else unit
 
+[@inline]
+let fail_if_xtz_greater_than_zero () : unit =
+  let amount = Tezos.amount in
+  if amount > 0tz
+    then failwith ff_extra_xtz_sent
+  else unit
+
+
 let main (param, storage : asset_entrypoints * asset_storage)
     : (operation list) * asset_storage =
+  let _ = fail_if_xtz_greater_than_zero () in
   match param with
   | Assets a ->
     let ops, new_assets = fa2_main (a, storage.assets) in

--- a/src/ff_interface.mligo
+++ b/src/ff_interface.mligo
@@ -41,6 +41,8 @@ let ff_token_not_found = "TOKEN_NOT_FOUND"
 let ff_token_metadata_not_found = "TOKEN_METADATA_NOT_FOUND"
 let ff_token_attribute_not_found = "TOKEN_ATTRIBUTE_NOT_FOUND"
 
+let ff_extra_xtz_sent = "EXTRA_XTZ_SENT"
+
 (** check if a token is not found *)
 let fail_if_token_not_found (token_id, ledger : nat * ledger) : unit =
   if not Big_map.mem token_id ledger

--- a/testnet-test/action_with_xtz.ts
+++ b/testnet-test/action_with_xtz.ts
@@ -1,0 +1,39 @@
+import * as dotenv from "dotenv";
+import {
+  TezosToolkit, TezosOperationError
+} from "@taquito/taquito";
+import {
+  InMemorySigner
+} from "@taquito/signer";
+dotenv.config();
+
+const Tezos = new TezosToolkit(<string>process.env.TEZOS_RPC_URL);
+
+const register_art = async function () {
+  const adminSigner = await InMemorySigner.fromSecretKey(<string>process.env.DEPLOYER_PRIVATE_KEY);
+  Tezos.setProvider({
+    signer: adminSigner
+  });
+
+  const contract = await Tezos.wallet.at(<string>process.env.CONTRACT_ADDRESS);
+  const adminAddress = await adminSigner.publicKeyHash()
+  try {
+    let op = await contract.methods.register_artworks([{
+      artist_name: "fail-test",
+      fingerprint: Uint8Array.from(Buffer.from("fail-test")),
+      title: "fail-test",
+      max_edition: 10,
+      royalty_address: adminAddress
+    }]).send({ amount: 0.1 });
+    await op.confirmation()
+    console.log(op)
+  } catch (error) {
+    if (error instanceof TezosOperationError) {
+      console.log(error.message)
+    } else {
+      console.log(error)
+    }
+  }
+}
+
+register_art()


### PR DESCRIPTION
To prevent users from send XTZ to token contract accidentally, we add a check before any entrypoint execution