### PR TITLE
Implement v2 contract

### DIFF
--- a/src/ff_interface.mligo
+++ b/src/ff_interface.mligo
@@ -7,6 +7,8 @@ type artwork =
   artist_name : string;
   fingerprint : bytes;
   max_edition : nat;
+  ae_amount : nat;
+  pp_amount : nat;
   token_start_id : nat;
   royalty_address : address;
 }

--- a/src/ff_minter.mligo
+++ b/src/ff_minter.mligo
@@ -23,6 +23,8 @@ type artwork_param =
   artist_name : string;
   fingerprint : bytes;
   max_edition : nat;
+  ae_amount : nat;
+  pp_amount : nat;
   royalty_address: address;
 }
 
@@ -45,7 +47,7 @@ let ff_duplicated_token_attribute = "TOKEN_ATTRIBUTE_HAS_ALREADY_REGISTERED"
 
 (** check if the token edition exceed the maximum number of the artwork *)
 let fail_if_invalid_edition (edition, artwork : nat * artwork) : unit =
-  if edition > artwork.max_edition
+  if edition >= artwork.max_edition + artwork.ae_amount + artwork.pp_amount
     then failwith ff_mint_invalid_edition
   else unit
 
@@ -118,6 +120,8 @@ let register_artworks(param, artworks, bytes_to_nat : artwork_param list * artwo
         fingerprint = artwork_param.fingerprint;
         title = artwork_param.title;
         max_edition = artwork_param.max_edition;
+        ae_amount = artwork_param.ae_amount;
+        pp_amount = artwork_param.pp_amount;
         token_start_id = artwork_id_nat;
         royalty_address = artwork_param.royalty_address;
       } in

--- a/testnet-test/register_artwork.ts
+++ b/testnet-test/register_artwork.ts
@@ -23,6 +23,8 @@ const register_art = async function () {
       fingerprint: Uint8Array.from(Buffer.from("IamFingerprint")),
       title: "test",
       max_edition: 10,
+      ae_amount: 1,
+      pp_amount: 1,
       royalty_address: adminAddress
     }]).send();
     await op.confirmation()


### PR DESCRIPTION
Implement v2 contract.
- `register_artworks`: add `ae_amount` and `pp_amount` to the artwork structure.
- `mint_editions`: now the `0` index edition will not be default consider as `AP`, so the actual mint amount should lower than `ae_amount + pp_amount + max_edition`